### PR TITLE
Guarantee `stack` property in TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,6 @@ console.log(ensureError(10));
 //=> [NonError: 10]
 ```
 */
-declare function ensureError<T>(input: T): IfAny<T, WithStack<Error>, T extends Error ? WithStack<T> : ensureError.NonError>;
+declare function ensureError<T>(input: T): IfAny<T, ErrorWithStack<Error>, T extends Error ? ErrorWithStack<T> : ensureError.NonError>;
 
 export = ensureError;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,15 @@
 declare namespace ensureError {
 	interface NonError extends Error {
 		name: 'NonError';
+		stack: string;
 	}
 }
 
 // IfAny<T, ThenType, ElseType> resolves to ThenType if T is `any` and resolves to ElseType otherwise
 // https://stackoverflow.com/a/49928360/4135063
 type IfAny<T, ThenType, ElseType> = 0 extends (1 & T) ? ThenType : ElseType;
+
+type WithStack<T> = T & { stack: string; };
 
 /**
 Ensures a value is a valid error by making it one if not.
@@ -31,6 +34,6 @@ console.log(ensureError(10));
 //=> [NonError: 10]
 ```
 */
-declare function ensureError<T>(input: T): IfAny<T, Error, T extends Error ? T : ensureError.NonError>;
+declare function ensureError<T>(input: T): IfAny<T, WithStack<Error>, T extends Error ? WithStack<T> : ensureError.NonError>;
 
 export = ensureError;

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare namespace ensureError {
 // https://stackoverflow.com/a/49928360/4135063
 type IfAny<T, ThenType, ElseType> = 0 extends (1 & T) ? ThenType : ElseType;
 
-type WithStack<T> = T & { stack: string; };
+type ErrorWithStack<T> = T & {stack: string};
 
 /**
 Ensures a value is a valid error by making it one if not.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,8 +8,8 @@ const error = new TypeError('🦄');
 expectAssignable<Error>(ensureError(10 as any));
 expectAssignable<TypeError>(ensureError(error));
 
-expectType<WithStack<Error>>(ensureError(10 as any));
-expectType<WithStack<TypeError>>(ensureError(error));
+expectType<ErrorWithStack<Error>>(ensureError(10 as any));
+expectType<ErrorWithStack<TypeError>>(ensureError(error));
 expectType<ensureError.NonError>(ensureError(10));
 
 // Ensure stack property

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,8 +1,18 @@
-import {expectType} from 'tsd';
+import {expectAssignable, expectType} from 'tsd';
 import ensureError = require('.');
+
+type WithStack<T> = T & { stack: string; };
 
 const error = new TypeError('🦄');
 
-expectType<Error>(ensureError(10 as any));
-expectType<TypeError>(ensureError(error));
+expectAssignable<Error>(ensureError(10 as any));
+expectAssignable<TypeError>(ensureError(error));
+
+expectType<WithStack<Error>>(ensureError(10 as any));
+expectType<WithStack<TypeError>>(ensureError(error));
 expectType<ensureError.NonError>(ensureError(10));
+
+// Ensure stack property
+expectType<string>(ensureError(10).stack);
+expectType<string>(ensureError(10 as any).stack);
+expectType<string>(ensureError(error).stack);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,7 @@
 import {expectAssignable, expectType} from 'tsd';
 import ensureError = require('.');
 
-type WithStack<T> = T & { stack: string; };
+type WithStack<T> = T & {stack: string};
 
 const error = new TypeError('🦄');
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,7 @@
 import {expectAssignable, expectType} from 'tsd';
 import ensureError = require('.');
 
-type WithStack<T> = T & {stack: string};
+type ErrorWithStack<T> = T & {stack: string};
 
 const error = new TypeError('🦄');
 


### PR DESCRIPTION
Currently TypeScript thinks that the `stack` property is `string | undefined`, although it should be `string`.