### PR TITLE
feat: add browser support via object-inspect

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
+          - 20
+          - 22
+          - 24
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
           - 22
           - 24
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface NonError extends Error {
 	name: 'NonError';
 	stack: string;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectAssignable, expectType} from 'tsd';
-import ensureError, {NonError} from './index.js';
+import ensureError, {type NonError} from './index.js';
 
 type ErrorWithStack<T> = T & {stack: string};
 

--- a/package.json
+++ b/package.json
@@ -37,8 +37,11 @@
 		"convert"
 	],
 	"devDependencies": {
-		"ava": "^4.1.0",
-		"tsd": "^0.19.1",
-		"xo": "^0.48.0"
+		"ava": "^6.4.1",
+		"tsd": "^0.33.0",
+		"xo": "^1.2.2"
+	},
+	"dependencies": {
+		"object-inspect": "^1.13.4"
 	}
 }


### PR DESCRIPTION
This is a really useful module, it would be great to use it in browser/react-native code also.

This PR switches to use the [`object-inspect`]() module for generating the error message on non-error objects, instead of Node's `util.inspect()`. Behaviour should be pretty similar, if not exactly the same for most cases. The impact of any changes would be a difference in the contents of `error.message` when calling `ensureError()` on a non-error object.

The tests were not passing when running with Node v20.19.4, due to a bug in `xo`, which I assume is due to the node version. Updating to latest `xo` fixes this. I also updated `tsd` and `ava` to the latest versions, and updated the github action to test on the current supported versions of Node.

Also updates github action steps to latest versions.